### PR TITLE
Fix BaseException handling to allow KeyboardInterrupt

### DIFF
--- a/retrying.py
+++ b/retrying.py
@@ -257,7 +257,7 @@ class Retrying(object):
 
             try:
                 attempt = Attempt(fn(*args, **kwargs), attempt_number, False)
-            except:
+            except Exception:
                 tb = sys.exc_info()
                 attempt = Attempt(tb, attempt_number, True)
 


### PR DESCRIPTION
Change bare except: to except Exception: to prevent catching BaseException subclasses like KeyboardInterrupt and SystemExit.

This allows users to interrupt retrying functions with Ctrl+C and prevents the library from interfering with system exit signals.

Fixes #12